### PR TITLE
cfn2py: prevent dictionary args from being used as a lookup key

### DIFF
--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import pprint
+import collections
 
 
 class object_registry(object):
@@ -19,7 +20,7 @@ class object_registry(object):
         return new_name
 
     def lookup(self, o):
-        if o in self.objects:
+        if isinstance(o, collections.Hashable) and o in self.objects:
             return self.objects[o]
         else:
             return output_value(o)

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -354,7 +354,7 @@ def do_outputs(d):
             if isinstance(pv, str):
                 print('    {}="{}",'.format(pk, pv))
             elif pk == 'Export':
-                print('    {}={}(name={})'.format(pk, pk, output_value(pv)))
+                print('    {}={}("{}")'.format(pk, pk, json.loads(output_value(pv))['Name']))
             else:
                 print('    {}={},'.format(pk, output_value(pv)))
         print("))")

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -354,7 +354,10 @@ def do_outputs(d):
             if isinstance(pv, str):
                 print('    {}="{}",'.format(pk, pv))
             elif pk == 'Export':
-                print('    {}={}("{}")'.format(pk, pk, json.loads(output_value(pv))['Name']))
+                ov = output_value(pv)
+                if ov[0] == '{': # Is a dictionary
+                    ov = json.loads(ov)['Name']
+                print('    {}={}("{}")'.format(pk, pk, ov))
             else:
                 print('    {}={},'.format(pk, output_value(pv)))
         print("))")


### PR DESCRIPTION
Fixes `TypeError: unhashable type: 'dict'` such as: https://github.com/cloudtools/troposphere/issues/229

Not known yet if this fix correct.